### PR TITLE
add include and exclude and skip bad data (not panicking)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,3 @@ gjson = "0.8.1"
 smallvec = "1.15.1"
 sysinfo = "0.37.2"
 memmap2 = "0.9.9"
-src = "0.0.6"
-
-
-# The profile that 'dist' will build with
-[profile.dist]
-inherits = "release"
-lto = "thin"

--- a/src/exact_dedup_memory.rs
+++ b/src/exact_dedup_memory.rs
@@ -248,14 +248,28 @@ fn exact_dedup_impl<K: DocHash>(
     };
 
     let pbar = build_pbar(input_paths.len(), "Paths");
+    let read_err_files = AtomicUsize::new(0);
+    let json_err_lines = AtomicUsize::new(0);
+    let hash_err_lines = AtomicUsize::new(0);
     input_paths.into_par_iter().for_each(|p| {
         let output_filename = get_output_filename(&p, input_dir, output_dir).unwrap();
-        let (p_seen, p_kept) =
-            exact_dedup_file(p, output_filename, text_key, &hash_key, &counter, &annotate).unwrap();
+        let (p_seen, p_kept) = exact_dedup_file(
+            p, output_filename, text_key, &hash_key, &counter, &annotate,
+            &read_err_files, &json_err_lines, &hash_err_lines,
+        ).unwrap();
         seen_docs.fetch_add(p_seen, Ordering::Relaxed);
         kept_docs.fetch_add(p_kept, Ordering::Relaxed);
         pbar.inc(1);
     });
+    let read_err = read_err_files.into_inner();
+    let json_err = json_err_lines.into_inner();
+    let hash_err = hash_err_lines.into_inner();
+    if read_err + json_err + hash_err > 0 {
+        println!(
+            "Skipped: {} files with read errors, {} lines with JSON errors, {} lines with hash errors",
+            read_err, json_err, hash_err
+        );
+    }
 
     let kept_docs = if let Some(_annokey) = annotate {
         counter.len()
@@ -306,6 +320,9 @@ fn exact_dedup_file<K: DocHash>(
     hash_key: &Option<String>,
     counter: &DashMap<K, usize>,
     annotate: &Option<String>,
+    read_err_files: &AtomicUsize,
+    json_err_lines: &AtomicUsize,
+    hash_err_lines: &AtomicUsize,
 ) -> Result<(usize, usize), Error> {
     let mut seen = 0;
     let mut kept = if let Some(_anno) = annotate {
@@ -318,28 +335,27 @@ fn exact_dedup_file<K: DocHash>(
     let data = read_pathbuf(&p, true).unwrap();
     for line in data.lines() {
         // Tolerate truncated .jsonl.zst files (premature EOF mid-frame) and malformed
-        // JSON lines: log and either stop reading this file (read error) or skip the
-        // line (json/hash error). Avoids panicking the rayon worker and lets us salvage
-        // everything readable up to the truncation point.
+        // JSON lines: bump a counter and either stop reading this file (read error) or
+        // skip the line (json/hash error). Aggregate counts are printed by the caller.
         let line = match line {
             Ok(l) => l,
-            Err(e) => {
-                eprintln!("[skip] read error in {}: {}", p.display(), e);
+            Err(_) => {
+                read_err_files.fetch_add(1, Ordering::Relaxed);
                 break;
             }
         };
         seen += 1;
         let mut line_json: Value = match serde_json::from_str(&line) {
             Ok(v) => v,
-            Err(e) => {
-                eprintln!("[skip] json error in {}: {}", p.display(), e);
+            Err(_) => {
+                json_err_lines.fetch_add(1, Ordering::Relaxed);
                 continue;
             }
         };
         let hash_val = match get_hash_val::<K>(&line_json, text_key, hash_key) {
             Ok(v) => v,
-            Err(e) => {
-                eprintln!("[skip] hash error in {}: {}", p.display(), e);
+            Err(_) => {
+                hash_err_lines.fetch_add(1, Ordering::Relaxed);
                 continue;
             }
         };

--- a/src/exact_dedup_memory.rs
+++ b/src/exact_dedup_memory.rs
@@ -172,14 +172,16 @@ pub fn exact_dedup_memory(
     hash_key: Option<String>,
     hash_bits: usize,
     annotate: Option<String>,
+    exclude_substring: String,
+    include_substring: String,
 ) -> Result<(), Error> {
     let start_main = Instant::now();
     println!("Starting exact deduplication");
 
     let (seen_docs, kept_docs) = match hash_bits {
-        64 => exact_dedup_impl::<u64>(input_dir, output_dir, text_key, hash_key, annotate).unwrap(),
+        64 => exact_dedup_impl::<u64>(input_dir, output_dir, text_key, hash_key, annotate, &exclude_substring, &include_substring).unwrap(),
         128 => {
-            exact_dedup_impl::<u128>(input_dir, output_dir, text_key, hash_key, annotate).unwrap()
+            exact_dedup_impl::<u128>(input_dir, output_dir, text_key, hash_key, annotate, &exclude_substring, &include_substring).unwrap()
         }
         _ => {
             return Err(anyhow!(
@@ -212,8 +214,28 @@ fn exact_dedup_impl<K: DocHash>(
     text_key: &String,
     hash_key: Option<String>,
     annotate: Option<String>,
+    exclude_substring: &str,
+    include_substring: &str,
 ) -> Result<(usize, usize), Error> {
-    let input_paths = expand_dirs(vec![input_dir.clone()], None).unwrap();
+    let raw_input_paths = expand_dirs(vec![input_dir.clone()], None).unwrap();
+    let n_before = raw_input_paths.len();
+    let input_paths: Vec<_> = raw_input_paths
+        .into_iter()
+        .filter(|p| {
+            let s = p.to_string_lossy();
+            (include_substring.is_empty() || s.contains(include_substring))
+                && (exclude_substring.is_empty() || !s.contains(exclude_substring))
+        })
+        .collect();
+    if !include_substring.is_empty() || !exclude_substring.is_empty() {
+        println!(
+            "Path filter: kept {} of {} (include={:?}, exclude={:?})",
+            input_paths.len(),
+            n_before,
+            include_substring,
+            exclude_substring
+        );
+    }
     let seen_docs = AtomicUsize::new(0);
     let kept_docs = AtomicUsize::new(0);
     let counter: DashMap<K, usize> = DashMap::new();
@@ -295,10 +317,32 @@ fn exact_dedup_file<K: DocHash>(
     let mut writer = create_writer(&output_filename).unwrap();
     let data = read_pathbuf(&p, true).unwrap();
     for line in data.lines() {
-        let line = line.unwrap();
+        // Tolerate truncated .jsonl.zst files (premature EOF mid-frame) and malformed
+        // JSON lines: log and either stop reading this file (read error) or skip the
+        // line (json/hash error). Avoids panicking the rayon worker and lets us salvage
+        // everything readable up to the truncation point.
+        let line = match line {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("[skip] read error in {}: {}", p.display(), e);
+                break;
+            }
+        };
         seen += 1;
-        let mut line_json: Value = serde_json::from_str(&line).unwrap();
-        let hash_val = get_hash_val::<K>(&line_json, text_key, hash_key).unwrap();
+        let mut line_json: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("[skip] json error in {}: {}", p.display(), e);
+                continue;
+            }
+        };
+        let hash_val = match get_hash_val::<K>(&line_json, text_key, hash_key) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("[skip] hash error in {}: {}", p.display(), e);
+                continue;
+            }
+        };
         if let Some(annotate_key) = annotate {
             let count = counter.get(&hash_val).unwrap();
             let anno_data = json!({"hash": hash_val.to_json(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,6 +274,16 @@ enum Commands {
         /// Can be nested, e.g., "metadata.duplicates"
         #[arg(long)]
         annotate_key: Option<String>,
+
+        /// Skip input paths whose string representation contains this substring.
+        /// Useful for excluding known-bad subtrees (e.g. "olmocr_science_pdfs").
+        #[arg(long, default_value_t = String::new())]
+        exclude_substring: String,
+
+        /// Keep only input paths whose string representation contains this substring.
+        /// Applied before --exclude-substring. Empty string (default) keeps all.
+        #[arg(long, default_value_t = String::new())]
+        include_substring: String,
     },
 
     /// Exact deduplication step 1/2: Group documents by hash
@@ -806,6 +816,8 @@ fn main() {
             hash_key,
             hash_bits,
             annotate_key,
+            exclude_substring,
+            include_substring,
         } => exact_dedup_memory(
             input_dir,
             output_dir,
@@ -813,6 +825,8 @@ fn main() {
             hash_key.clone(),
             *hash_bits,
             annotate_key.clone(),
+            exclude_substring.clone(),
+            include_substring.clone(),
         ),
 
         Commands::ExactDedupDiskGroup {


### PR DESCRIPTION
## Summary

Two small features and one cleanup for `exact-dedup-memory`:

- **Tolerate bad input without panicking.** A truncated `.jsonl.zst` shard (premature EOF mid-frame) or a malformed JSON line previously panicked the rayon worker and aborted the run. Both are now logged and skipped — a read error stops that one file; a JSON/hash error skips that one line. The deduper continues, salvaging everything decodable.

- **`--include-substring` / `--exclude-substring` path filters.** Restrict the input set by substring match on the file path, without having to rearrange the source tree. Both default to empty (no filter). `include` is applied before `exclude`. A startup line reports `Path filter: kept N of M` so the filter is easy to verify.

## Motivation

I ran into a real-world corpus where ~45% of one subtree's `.jsonl.zst` shards were truncated mid-frame. The deduper panicked at the first bad file and never finished. With these changes, the same run completes — every clean file is fully deduped, every truncated file contributes its salvageable prefix, and a single flag (`--exclude-substring`) lets me drop the whole bad subtree if I prefer that over salvage.